### PR TITLE
Support JIRA labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,22 @@ Automatically label Pull Requests with the associated Jira issue's component nam
 
 ## Methods
 
-### `configure(jira_url:, jira_username:, jira_api_token:)` 
+### `configure(jira_url:, jira_username:, jira_api_token:)`
 Configures the Jira Client with your credentials
 
 **Params**
-  - `jira_url [String]` - The full url to your Jira instance, e.g., "https://myjirainstance.atlassian.net" 
+  - `jira_url [String]` - The full url to your Jira instance, e.g., "https://myjirainstance.atlassian.net"
   - `jira_username [String]` - The username to use for accessing the Jira instance. Commonly, this is an email address
   - `jira_api_token [String]` - The API key to use to access the Jira instance. Generate one here: https://id.atlassian.com/manage/api-tokens
 
 **Returns**
  - `[JIRA::Client]` - The underlying `JIRA::Client` instance
 
-### `autolabel_pull_request(issue_prefixes)` 
+### `autolabel_pull_request(issue_prefixes)`
 Labels the Pull Request with Jira Project Keys and Component Names
+
+### `autolabel_pull_request(issue_prefixes, project: true, components: true, labels: true)`
+Labels the Pull Request with Jira Project Keys and Component Names and Labels
 
 **Params**
   - `issue_prefixes [Array<String>]` - An array of issue key prefixes; this is often the project key. These must be present in the title or body of the Pull Request

--- a/lib/jira_sync/plugin.rb
+++ b/lib/jira_sync/plugin.rb
@@ -114,20 +114,20 @@ module Danger
     end
 
     def fetch_labels_from_issues(issue_keys, project: true, components: true, labels: false)
-      labels = []
+      issue_labels = []
       issue_keys.each do |key|
         begin
           issue = @jira_client.Issue.find(key)
-          labels << issue.project.key if project
-          labels += issue.components.map(&:name) if components
-          labels += issue.fields["labels"] if labels
+          issue_labels << issue.project.key if project
+          issue_labels += issue.components.map(&:name) if components
+          issue_labels += issue.fields["labels"] if labels
         rescue JIRA::HTTPError => e
           warn "#{e.code} Error while retrieving JIRA issue \"#{key}\": #{e.message}"
           # No reason to continue if Unauthorized
           break if e.code == 503
         end
       end
-      labels.compact.uniq
+      issue_labels.compact.uniq
     end
 
     def create_missing_github_labels(labels)

--- a/lib/jira_sync/plugin.rb
+++ b/lib/jira_sync/plugin.rb
@@ -65,14 +65,19 @@ module Danger
     # @return [Array<String>, nil] The list of project & component labels
     #   that were applied or nil if no issue or labels were found
     #
-    def autolabel_pull_request(issue_prefixes)
+    def autolabel_pull_request(issue_prefixes, project: true, components: true, labels: false)
       raise NotConfiguredError unless @jira_client
       raise(ArgumentError, "issue_prefixes cannot be empty") if issue_prefixes.empty?
 
       issue_keys = extract_issue_keys_from_pull_request(issue_prefixes)
       return if issue_keys.empty?
 
-      labels = fetch_labels_from_issues(issue_keys)
+      labels = fetch_labels_from_issues(
+        issue_keys,
+        project: project,
+        components: components,
+        labels: labels
+      )
       return if labels.empty?
 
       create_missing_github_labels(labels)
@@ -108,13 +113,14 @@ module Danger
       keys.compact.uniq
     end
 
-    def fetch_labels_from_issues(issue_keys)
+    def fetch_labels_from_issues(issue_keys, project: true, components: true, labels: false)
       labels = []
       issue_keys.each do |key|
         begin
           issue = @jira_client.Issue.find(key)
-          labels << issue.project.key
-          labels += issue.components.map(&:name)
+          labels << issue.project.key if project
+          labels += issue.components.map(&:name) if components
+          labels += issue.fields["labels"] if labels
         rescue JIRA::HTTPError => e
           warn "#{e.code} Error while retrieving JIRA issue \"#{key}\": #{e.message}"
           # No reason to continue if Unauthorized


### PR DESCRIPTION
Thanks for making this plugin! We use labels throughout or projects so we can attach them across projects. It's a little more flexible for us. This PR adds support for JIRA labels, as well as not allowing the component or project labels to come in. We also have separate repos for each project, so it's a little redundant for us to have "WEB" in every single PR under the WEB git repo.