### PR TITLE
[security/update_yard] Set minimal yard version that has CVE fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,7 +151,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    yard (0.9.14)
+    yard (0.9.20)
 
 PLATFORMS
   ruby
@@ -171,7 +171,7 @@ DEPENDENCIES
   simplecov
   vcr
   webmock
-  yard
+  yard (~> 0.9.20)
 
 BUNDLED WITH
    1.16.2

--- a/danger-jira_sync.gemspec
+++ b/danger-jira_sync.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
 
   # Linting code and docs
   spec.add_development_dependency "rubocop"
-  spec.add_development_dependency "yard"
+  spec.add_development_dependency "yard", "~> 0.9.20"
 
   # Makes testing easy via `bundle exec guard`
   spec.add_development_dependency "guard", "~> 2.14"

--- a/lib/jira_sync/gem_version.rb
+++ b/lib/jira_sync/gem_version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JiraSync
-  VERSION = "0.0.7"
+  VERSION = "0.0.8"
 end


### PR DESCRIPTION
Bumping version to 0.0.8

https://github.com/lsegal/yard/security/advisories/GHSA-xfhh-rx56-rxcr